### PR TITLE
feat: Configurable directory exclusions for script search

### DIFF
--- a/lua/termlet/init.lua
+++ b/lua/termlet/init.lua
@@ -150,8 +150,9 @@ local function should_exclude_file(name, search_config)
   search_config = search_config or config.search
 
   for _, pattern in ipairs(search_config.exclude_patterns or {}) do
-    -- Convert glob pattern to Lua pattern: * -> .*, ? -> ., . -> %.
-    local lua_pattern = "^" .. pattern:gsub("%.", "%%."):gsub("%*", ".*"):gsub("%?", ".") .. "$"
+    -- Escape all Lua pattern metacharacters first, then convert glob wildcards
+    local lua_pattern = pattern:gsub("([%(%)%.%%%+%-%[%]%^%$])", "%%%1")
+    lua_pattern = "^" .. lua_pattern:gsub("%*", ".*"):gsub("%?", ".") .. "$"
     if name:match(lua_pattern) then
       return true
     end
@@ -308,7 +309,13 @@ function M.find_script_by_name(filename, root_dir, search_dirs)
   local function search_in_dir(dir_path, target_file, max_depth)
     max_depth = max_depth or 5 -- Increased depth for root-based search
     if max_depth <= 0 then return nil end
-    
+
+    -- Check if the target file itself is excluded by patterns
+    if should_exclude_file(target_file, config.search) then
+      debug_log("Skipping excluded target file: " .. target_file)
+      return nil
+    end
+
     local full_path = dir_path .. "/" .. target_file
     if vim.fn.filereadable(full_path) == 1 then
       debug_log("Found script at: " .. full_path)
@@ -340,10 +347,14 @@ function M.find_script_by_name(filename, root_dir, search_dirs)
   end
   
   -- First, try direct search in root directory
-  local direct_path = search_root .. "/" .. filename
-  if vim.fn.filereadable(direct_path) == 1 then
-    debug_log("Found script directly at: " .. direct_path)
-    return direct_path
+  if not should_exclude_file(filename, config.search) then
+    local direct_path = search_root .. "/" .. filename
+    if vim.fn.filereadable(direct_path) == 1 then
+      debug_log("Found script directly at: " .. direct_path)
+      return direct_path
+    end
+  else
+    debug_log("Skipping excluded file in direct search: " .. filename)
   end
   
   -- Then search in common script directories within root


### PR DESCRIPTION
## Summary
- Add `search` configuration section with `exclude_dirs`, `exclude_hidden`, and `exclude_patterns` options
- Replace hardcoded directory exclusions (`.git`, `node_modules`, hidden dirs) with configurable helpers
- Include sensible defaults covering common build artifacts and VCS directories across languages
- Add comprehensive tests (28 new test cases) for exclusion logic and configuration merging

## Details

Closes #14

### New Configuration Options

```lua
termlet.setup({
  search = {
    -- Directories to exclude from script search
    exclude_dirs = {
      "node_modules", ".git", ".svn", ".hg",
      "dist", "build", "target", "__pycache__",
      ".cache", ".tox", ".mypy_cache", ".pytest_cache",
      "vendor", "venv", ".venv", "env",
    },
    -- Whether to exclude hidden directories (starting with .)
    exclude_hidden = true,
    -- Glob-style patterns to exclude files
    exclude_patterns = {
      "*.min.*",    -- Minified files
      "*.bundle.*", -- Bundled files
    },
  }
})
```

### Implementation

- `should_exclude_dir(name, search_config)` — checks directory names against exclusion list and hidden dir flag
- `should_exclude_file(name, search_config)` — matches filenames against glob patterns (`*` and `?` wildcards)
- Both functions fall back to `config.search` when called without explicit search_config
- `search_in_dir` in `find_script_by_name` now uses these helpers instead of hardcoded checks
- Debug logging for skipped directories and files

### Acceptance Criteria

- [x] Users can configure excluded directories
- [x] Users can toggle hidden directory exclusion
- [x] Default exclusions are sensible for common project types
- [x] Configuration can extend or replace defaults
- [x] Debug logging shows which directories are being skipped

## Test plan
- [x] All 98 existing + new tests pass (29 menu + 69 termlet)
- [x] `should_exclude_dir` tests: hidden dirs, explicit exclusion list, empty list, combined behavior, nil fallback, all defaults
- [x] `should_exclude_file` tests: glob patterns, multiple patterns, empty patterns, `?` wildcard, nil fallback
- [x] Search configuration tests: custom config, partial merge, full replacement, pattern addition
- [x] Pre-existing tests (title formatting, terminal styling, validation) continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)