### PR TITLE
feat: Script history and quick re-run

### DIFF
--- a/lua/termlet/history.lua
+++ b/lua/termlet/history.lua
@@ -56,7 +56,7 @@ end
 --- Get all history entries
 ---@return table List of history entries
 function M.get_entries()
-  return state.entries
+  return { unpack(state.entries) }
 end
 
 --- Get the most recent history entry
@@ -242,15 +242,15 @@ local function render_history()
       if entry.exit_code == 0 then
         table.insert(highlights, {
           line = #lines - 1,
-          col_start = is_selected and 4 or 4,
-          col_end = is_selected and 5 or 5,
+          col_start = 4,
+          col_end = 7,
           group = state.config.highlight.success
         })
       else
         table.insert(highlights, {
           line = #lines - 1,
-          col_start = is_selected and 4 or 4,
-          col_end = is_selected and 5 or 5,
+          col_start = 4,
+          col_end = 7,
           group = state.config.highlight.error
         })
       end

--- a/lua/termlet/init.lua
+++ b/lua/termlet/init.lua
@@ -602,7 +602,16 @@ local function execute_script(script)
             execution_time = execution_time,
             timestamp = os.time(),
             working_dir = cwd,
-            script = script, -- Store script config for re-running
+            script = {
+              name = script.name,
+              filename = script.filename,
+              root_dir = script.root_dir,
+              dir_name = script.dir_name,
+              relative_path = script.relative_path,
+              cmd = script.cmd,
+              search_dirs = script.search_dirs,
+              description = script.description,
+            },
           })
         end
       end)
@@ -1232,7 +1241,7 @@ function M.show_history()
     else
       vim.notify("Script configuration not found in history", vim.log.levels.ERROR)
     end
-  end, config.history)
+  end)
 end
 
 --- Close the history browser

--- a/tests/history_spec.lua
+++ b/tests/history_spec.lua
@@ -13,7 +13,7 @@ describe("termlet.history", function()
 
   after_each(function()
     -- Clean up
-    if history.is_open then
+    if history.is_open() then
       history.close()
     end
     history.clear_history()


### PR DESCRIPTION
## Summary
Implements script execution history tracking and quick re-run functionality as requested in issue #48.

## Features Implemented
- ✅ Track script execution history with comprehensive metadata:
  - Script name
  - Exit code
  - Execution time (accurate duration measurement)
  - Timestamp
  - Working directory
  - Full script configuration for accurate re-runs

- ✅ Interactive history browser UI:
  - Mason-like popup interface
  - Color-coded exit status (green ✓ for success, red ✗ for failure)
  - Formatted execution times (ms, s, m, h)
  - Vim-like navigation (j/k, gg/G)
  - Press Enter to re-run selected script
  - Press 'c' to clear history
  - Press 'q' or Esc to close

- ✅ API Functions:
  - `require('termlet').show_history()` - Open interactive history browser
  - `require('termlet').rerun_last()` - Re-run most recent script
  - `require('termlet').get_history()` - Get all history entries
  - `require('termlet').clear_history()` - Clear all history
  - `require('termlet').toggle_history()` - Toggle history browser
  - `require('termlet').is_history_open()` - Check if browser is open

- ✅ Configuration options:
  - `history.enabled` (default: true) - Enable/disable history tracking
  - `history.max_entries` (default: 50) - Maximum history entries to keep

## Benefits
- Quick iteration during development - re-run scripts without navigating menus
- Visibility into script success/failure patterns
- Similar to shell history (`Ctrl+R`) but script-specific
- Automatic cleanup with configurable max entries

## Usage Examples

### Basic usage:
```lua
-- Re-run the last script
vim.keymap.set("n", "<leader>tr", function()
  require("termlet").rerun_last()
end, { desc = "Re-run last script" })

-- Open history browser
vim.keymap.set("n", "<leader>th", function()
  require("termlet").show_history()
end, { desc = "Show script history" })
```

### Configuration:
```lua
require("termlet").setup({
  scripts = { ... },
  history = {
    enabled = true,
    max_entries = 100,  -- Keep more history
  },
})
```

## Implementation Details
- New `lua/termlet/history.lua` module for history management
- Integration with `execute_script()` to automatically track executions
- Uses `vim.loop.hrtime()` for accurate execution time measurement
- Stores full script configuration for reliable re-runs
- FIFO eviction when max_entries limit is reached

## Testing
- Comprehensive test suite in `tests/history_spec.lua`
- 40+ test cases covering:
  - Entry addition and retrieval
  - Max entries enforcement
  - History clearing
  - UI state management
  - Integration with termlet module
  - Edge cases and error handling
- Manual integration test passed successfully

## Files Changed
- `lua/termlet/init.lua` - Added history module integration and API functions
- `lua/termlet/history.lua` - New history management module (490 lines)
- `tests/history_spec.lua` - New comprehensive test suite (589 lines)

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)