### PR TITLE
feat: Collaborative sharing - export/import script configurations

### DIFF
--- a/lua/termlet/export_import.lua
+++ b/lua/termlet/export_import.lua
@@ -1,0 +1,699 @@
+-- TermLet Export/Import Module
+-- Enables sharing script configurations through export/import functionality
+-- Supports JSON format with sensitive data stripping and merge/replace import modes
+
+local M = {}
+
+-- Module state
+local state = {
+  buf = nil,
+  win = nil,
+  preview_data = nil, -- Parsed import data awaiting confirmation
+  preview_callback = nil, -- Callback for import confirmation
+  preview_mode = "merge", -- "merge" or "replace"
+}
+
+-- Highlight namespace
+local ns_id = vim.api.nvim_create_namespace("termlet_export_import")
+
+-- Default preview UI configuration
+local default_preview_config = {
+  width_ratio = 0.7,
+  height_ratio = 0.6,
+  border = "rounded",
+  title = " TermLet Import Preview ",
+  highlight = {
+    selected = "CursorLine",
+    title = "Title",
+    help = "Comment",
+    added = "DiagnosticOk",
+    conflict = "DiagnosticWarn",
+  },
+}
+
+-- Fields considered sensitive and stripped during export
+local sensitive_fields = {
+  "env",
+  "root_dir",
+  "search_dirs",
+}
+
+-- Fields that are valid for a script configuration
+local valid_script_fields = {
+  name = "string",
+  filename = "string",
+  cmd = "string",
+  description = "string",
+  dir_name = "string",
+  relative_path = "string",
+  root_dir = "string",
+  search_dirs = "table",
+  depends_on = "table",
+  run_after_deps = "string",
+  filters = "table",
+  env = "table",
+}
+
+--- Strip sensitive fields from a script configuration
+---@param script table Script configuration
+---@param fields table|nil List of field names to strip (defaults to sensitive_fields)
+---@return table Cleaned script configuration
+local function strip_sensitive(script, fields)
+  fields = fields or sensitive_fields
+  local cleaned = {}
+  local strip_set = {}
+  for _, field in ipairs(fields) do
+    strip_set[field] = true
+  end
+
+  for key, value in pairs(script) do
+    if not strip_set[key] then
+      if type(value) == "table" then
+        cleaned[key] = vim.deepcopy(value)
+      else
+        cleaned[key] = value
+      end
+    end
+  end
+
+  return cleaned
+end
+
+--- Validate a single script configuration
+---@param script table Script to validate
+---@return boolean valid
+---@return string|nil error_message
+local function validate_script(script)
+  if type(script) ~= "table" then
+    return false, "Script must be a table"
+  end
+
+  if not script.name or type(script.name) ~= "string" or script.name == "" then
+    return false, "Script must have a non-empty 'name' string field"
+  end
+
+  -- Must have either filename or dir_name+relative_path
+  local has_filename = script.filename and type(script.filename) == "string"
+  local has_legacy = script.dir_name
+    and type(script.dir_name) == "string"
+    and script.relative_path
+    and type(script.relative_path) == "string"
+
+  if not has_filename and not has_legacy then
+    return false, "Script '" .. script.name .. "' must have 'filename' or both 'dir_name' and 'relative_path'"
+  end
+
+  -- Validate field types
+  for key, value in pairs(script) do
+    local expected_type = valid_script_fields[key]
+    if expected_type and type(value) ~= expected_type then
+      return false,
+        "Script '" .. script.name .. "': field '" .. key .. "' should be " .. expected_type .. ", got " .. type(value)
+    end
+  end
+
+  -- Validate depends_on entries are strings
+  if script.depends_on then
+    for i, dep in ipairs(script.depends_on) do
+      if type(dep) ~= "string" then
+        return false, "Script '" .. script.name .. "': depends_on[" .. i .. "] must be a string"
+      end
+    end
+  end
+
+  -- Validate run_after_deps value
+  if script.run_after_deps then
+    local valid_modes = { all = true, any = true, none = true }
+    if not valid_modes[script.run_after_deps] then
+      return false, "Script '" .. script.name .. "': run_after_deps must be 'all', 'any', or 'none'"
+    end
+  end
+
+  return true, nil
+end
+
+--- Validate an import data structure
+---@param data table Parsed import data
+---@return boolean valid
+---@return string|nil error_message
+function M.validate_import_data(data)
+  if type(data) ~= "table" then
+    return false, "Import data must be a table"
+  end
+
+  if not data.scripts or type(data.scripts) ~= "table" then
+    return false, "Import data must contain a 'scripts' table"
+  end
+
+  if #data.scripts == 0 then
+    return false, "Import data contains no scripts"
+  end
+
+  -- Validate each script
+  local seen_names = {}
+  for i, script in ipairs(data.scripts) do
+    local valid, err = validate_script(script)
+    if not valid then
+      return false, "Script " .. i .. ": " .. err
+    end
+
+    -- Check for duplicate names
+    if seen_names[script.name] then
+      return false, "Duplicate script name: '" .. script.name .. "'"
+    end
+    seen_names[script.name] = true
+  end
+
+  return true, nil
+end
+
+--- Export scripts to JSON format
+---@param scripts table List of script configurations
+---@param opts table|nil Export options: { strip_sensitive = true, include_fields = nil, exclude_fields = nil }
+---@return string|nil json_string
+---@return string|nil error_message
+function M.export_json(scripts, opts)
+  opts = opts or {}
+  local strip = opts.strip_sensitive ~= false -- Default: true
+
+  if not scripts or type(scripts) ~= "table" or #scripts == 0 then
+    return nil, "No scripts to export"
+  end
+
+  -- Build export data
+  local export_scripts = {}
+  for _, script in ipairs(scripts) do
+    local exported
+    if strip then
+      exported = strip_sensitive(script, opts.exclude_fields)
+    else
+      exported = vim.deepcopy(script)
+    end
+
+    -- Only include specified fields if include_fields is set
+    if opts.include_fields then
+      local filtered = {}
+      local include_set = {}
+      for _, field in ipairs(opts.include_fields) do
+        include_set[field] = true
+      end
+      -- Always include name and filename/dir_name+relative_path
+      include_set["name"] = true
+      include_set["filename"] = true
+      include_set["dir_name"] = true
+      include_set["relative_path"] = true
+
+      for key, value in pairs(exported) do
+        if include_set[key] then
+          filtered[key] = value
+        end
+      end
+      exported = filtered
+    end
+
+    -- Remove internal/runtime fields that shouldn't be exported
+    exported.on_stdout = nil
+    exported.on_exit = nil
+
+    table.insert(export_scripts, exported)
+  end
+
+  local export_data = {
+    version = 1,
+    scripts = export_scripts,
+  }
+
+  -- Metadata
+  if opts.include_metadata ~= false then
+    export_data.metadata = {
+      exported_at = os.date("%Y-%m-%dT%H:%M:%S"),
+      script_count = #export_scripts,
+    }
+  end
+
+  local ok, json_str = pcall(vim.fn.json_encode, export_data)
+  if not ok then
+    return nil, "Failed to encode JSON: " .. tostring(json_str)
+  end
+
+  return json_str, nil
+end
+
+--- Export scripts to a file
+---@param scripts table List of script configurations
+---@param filepath string Output file path
+---@param opts table|nil Export options (same as export_json)
+---@return boolean success
+---@return string|nil error_message
+function M.export_to_file(scripts, filepath, opts)
+  local json_str, err = M.export_json(scripts, opts)
+  if not json_str then
+    return false, err
+  end
+
+  -- Expand path
+  filepath = vim.fn.expand(filepath)
+
+  -- Ensure parent directory exists
+  local parent_dir = vim.fn.fnamemodify(filepath, ":h")
+  if vim.fn.isdirectory(parent_dir) == 0 then
+    return false, "Directory does not exist: " .. parent_dir
+  end
+
+  -- Write file
+  local file, write_err = io.open(filepath, "w")
+  if not file then
+    return false, "Failed to open file for writing: " .. tostring(write_err)
+  end
+
+  file:write(json_str)
+  file:write("\n")
+  file:close()
+
+  return true, nil
+end
+
+--- Parse JSON import data from a string
+---@param json_str string JSON string
+---@return table|nil data
+---@return string|nil error_message
+function M.parse_json(json_str)
+  if not json_str or json_str == "" then
+    return nil, "Empty input"
+  end
+
+  local ok, data = pcall(vim.fn.json_decode, json_str)
+  if not ok then
+    return nil, "Invalid JSON: " .. tostring(data)
+  end
+
+  return data, nil
+end
+
+--- Import scripts from a file
+---@param filepath string Input file path
+---@return table|nil data Parsed and validated import data
+---@return string|nil error_message
+function M.import_from_file(filepath)
+  -- Expand path
+  filepath = vim.fn.expand(filepath)
+
+  if vim.fn.filereadable(filepath) ~= 1 then
+    return nil, "File not found: " .. filepath
+  end
+
+  local file, read_err = io.open(filepath, "r")
+  if not file then
+    return nil, "Failed to open file: " .. tostring(read_err)
+  end
+
+  local content = file:read("*a")
+  file:close()
+
+  if not content or content == "" then
+    return nil, "File is empty: " .. filepath
+  end
+
+  -- Parse based on file extension
+  local ext = vim.fn.fnamemodify(filepath, ":e"):lower()
+  local data, err
+
+  if ext == "json" then
+    data, err = M.parse_json(content)
+  else
+    -- Default to JSON
+    data, err = M.parse_json(content)
+  end
+
+  if not data then
+    return nil, err
+  end
+
+  -- Validate
+  local valid, validate_err = M.validate_import_data(data)
+  if not valid then
+    return nil, validate_err
+  end
+
+  return data, nil
+end
+
+--- Merge imported scripts with existing scripts
+--- New scripts are added, existing scripts with the same name are updated
+---@param existing table Existing scripts list
+---@param imported table Imported scripts list
+---@return table merged Merged scripts list
+---@return table changes Summary of changes { added = {}, updated = {}, unchanged = {} }
+function M.merge_scripts(existing, imported)
+  -- Build lookup of existing scripts by name
+  local existing_map = {}
+  for i, script in ipairs(existing) do
+    existing_map[script.name] = { index = i, script = script }
+  end
+
+  local merged = vim.deepcopy(existing)
+  local changes = {
+    added = {},
+    updated = {},
+    unchanged = {},
+  }
+
+  for _, imp_script in ipairs(imported) do
+    local existing_entry = existing_map[imp_script.name]
+    if existing_entry then
+      -- Update existing script (merge fields)
+      merged[existing_entry.index] = vim.tbl_deep_extend("force", existing_entry.script, imp_script)
+      table.insert(changes.updated, imp_script.name)
+    else
+      -- Add new script
+      table.insert(merged, vim.deepcopy(imp_script))
+      table.insert(changes.added, imp_script.name)
+    end
+  end
+
+  -- Track unchanged scripts
+  for _, script in ipairs(existing) do
+    local found = false
+    for _, name in ipairs(changes.updated) do
+      if name == script.name then
+        found = true
+        break
+      end
+    end
+    if not found then
+      table.insert(changes.unchanged, script.name)
+    end
+  end
+
+  return merged, changes
+end
+
+--- Calculate preview window dimensions
+---@param config table UI configuration
+---@return table Window options for nvim_open_win
+local function calculate_window_opts(config)
+  local width = math.floor(vim.o.columns * config.width_ratio)
+  local height = math.floor(vim.o.lines * config.height_ratio)
+
+  -- Minimum dimensions
+  width = math.max(width, 60)
+  height = math.max(height, 15)
+
+  local row = math.floor((vim.o.lines - height) / 2)
+  local col = math.floor((vim.o.columns - width) / 2)
+
+  return {
+    relative = "editor",
+    width = width,
+    height = height,
+    row = row,
+    col = col,
+    anchor = "NW",
+    style = "minimal",
+    border = config.border,
+    title = config.title,
+    title_pos = "center",
+    footer = " [Enter] Confirm  [m] Toggle Mode  [q] Cancel ",
+    footer_pos = "center",
+  }
+end
+
+--- Render the import preview UI
+local function render_preview()
+  if not state.buf or not vim.api.nvim_buf_is_valid(state.buf) then
+    return
+  end
+
+  local config = state.preview_config or default_preview_config
+  local win_opts = calculate_window_opts(config)
+  local width = win_opts.width - 2 -- Account for borders
+
+  -- Clear existing content and highlights
+  vim.api.nvim_buf_clear_namespace(state.buf, ns_id, 0, -1)
+
+  local lines = {}
+  local highlights = {}
+
+  -- Header
+  table.insert(lines, "")
+  local mode_str = state.preview_mode == "merge" and "MERGE" or "REPLACE"
+  local header = "  Import Mode: " .. mode_str
+  table.insert(lines, header)
+  table.insert(highlights, { line = #lines - 1, group = config.highlight.title })
+  table.insert(lines, "  " .. string.rep("─", width - 4))
+
+  if state.preview_data and state.preview_data.scripts then
+    -- Show metadata if available
+    if state.preview_data.metadata then
+      local meta = state.preview_data.metadata
+      if meta.exported_at then
+        table.insert(lines, "  Exported: " .. meta.exported_at)
+        table.insert(highlights, { line = #lines - 1, group = config.highlight.help })
+      end
+      if meta.script_count then
+        table.insert(lines, "  Scripts: " .. meta.script_count)
+        table.insert(highlights, { line = #lines - 1, group = config.highlight.help })
+      end
+      table.insert(lines, "")
+    end
+
+    -- Show changes summary
+    if state.preview_changes then
+      local changes = state.preview_changes
+      if #changes.added > 0 then
+        table.insert(lines, "  + New: " .. table.concat(changes.added, ", "))
+        table.insert(highlights, { line = #lines - 1, group = config.highlight.added })
+      end
+      if #changes.updated > 0 then
+        table.insert(lines, "  ~ Updated: " .. table.concat(changes.updated, ", "))
+        table.insert(highlights, { line = #lines - 1, group = config.highlight.conflict })
+      end
+      if #changes.unchanged > 0 then
+        table.insert(lines, "  = Unchanged: " .. table.concat(changes.unchanged, ", "))
+        table.insert(highlights, { line = #lines - 1, group = config.highlight.help })
+      end
+      table.insert(lines, "")
+    end
+
+    table.insert(lines, "  " .. string.rep("─", width - 4))
+    table.insert(lines, "")
+
+    -- Show scripts to import
+    table.insert(lines, "  Scripts:")
+    table.insert(highlights, { line = #lines - 1, group = config.highlight.title })
+    table.insert(lines, "")
+
+    for _, script in ipairs(state.preview_data.scripts) do
+      local line = "    " .. script.name
+      if script.description then
+        line = line .. " - " .. script.description
+      end
+      table.insert(lines, line)
+
+      -- Show script details
+      if script.filename then
+        table.insert(lines, "      filename: " .. script.filename)
+        table.insert(highlights, { line = #lines - 1, group = config.highlight.help })
+      end
+      if script.cmd then
+        table.insert(lines, "      cmd: " .. script.cmd)
+        table.insert(highlights, { line = #lines - 1, group = config.highlight.help })
+      end
+      if script.depends_on and #script.depends_on > 0 then
+        table.insert(lines, "      depends_on: " .. table.concat(script.depends_on, ", "))
+        table.insert(highlights, { line = #lines - 1, group = config.highlight.help })
+      end
+      table.insert(lines, "")
+    end
+  else
+    table.insert(lines, "")
+    table.insert(lines, "    No scripts found in import data")
+    table.insert(lines, "")
+  end
+
+  -- Pad to fill window
+  local target_height = win_opts.height - 2
+  while #lines < target_height do
+    table.insert(lines, "")
+  end
+
+  -- Set buffer content
+  vim.bo[state.buf].modifiable = true
+  vim.api.nvim_buf_set_lines(state.buf, 0, -1, false, lines)
+  vim.bo[state.buf].modifiable = false
+
+  -- Apply highlights
+  for _, hl in ipairs(highlights) do
+    if hl.col_start and hl.col_end then
+      vim.api.nvim_buf_add_highlight(state.buf, ns_id, hl.group, hl.line, hl.col_start, hl.col_end)
+    else
+      vim.api.nvim_buf_add_highlight(state.buf, ns_id, hl.group, hl.line, 0, -1)
+    end
+  end
+end
+
+--- Toggle import mode between merge and replace
+local function toggle_mode()
+  if state.preview_mode == "merge" then
+    state.preview_mode = "replace"
+  else
+    state.preview_mode = "merge"
+  end
+
+  -- Recalculate changes based on new mode
+  if state.preview_mode == "replace" then
+    state.preview_changes = {
+      added = {},
+      updated = {},
+      unchanged = {},
+    }
+    for _, script in ipairs(state.preview_data.scripts) do
+      table.insert(state.preview_changes.added, script.name)
+    end
+  elseif state.existing_scripts then
+    local _, changes = M.merge_scripts(state.existing_scripts, state.preview_data.scripts)
+    state.preview_changes = changes
+  end
+
+  render_preview()
+end
+
+--- Confirm import
+local function confirm_import()
+  if not state.preview_data or not state.preview_callback then
+    return
+  end
+
+  local data = state.preview_data
+  local mode = state.preview_mode
+  local callback = state.preview_callback
+
+  M.close_preview()
+
+  vim.schedule(function()
+    callback(data, mode)
+  end)
+end
+
+--- Set up keymaps for the preview buffer
+local function setup_keymaps()
+  local buf = state.buf
+  local opts = { noremap = true, silent = true, buffer = buf }
+
+  vim.keymap.set("n", "<CR>", confirm_import, opts)
+  vim.keymap.set("n", "<Enter>", confirm_import, opts)
+  vim.keymap.set("n", "m", toggle_mode, opts)
+  vim.keymap.set("n", "q", M.close_preview, opts)
+  vim.keymap.set("n", "<Esc>", M.close_preview, opts)
+end
+
+--- Open import preview UI
+---@param import_data table Parsed import data
+---@param existing_scripts table Current scripts for merge comparison
+---@param callback function Called with (data, mode) on confirmation
+---@param ui_config table|nil Optional UI configuration
+---@return boolean success
+function M.open_preview(import_data, existing_scripts, callback, ui_config)
+  -- Close existing window if open
+  if state.win and vim.api.nvim_win_is_valid(state.win) then
+    M.close_preview()
+  end
+
+  if not import_data or not import_data.scripts or #import_data.scripts == 0 then
+    vim.notify("No scripts to import", vim.log.levels.WARN)
+    return false
+  end
+
+  -- Initialize state
+  state.preview_data = import_data
+  state.preview_callback = callback
+  state.preview_mode = "merge"
+  state.existing_scripts = existing_scripts
+  state.preview_config = vim.tbl_deep_extend("force", default_preview_config, ui_config or {})
+
+  -- Calculate initial changes for merge mode
+  local _, changes = M.merge_scripts(existing_scripts or {}, import_data.scripts)
+  state.preview_changes = changes
+
+  -- Create buffer
+  state.buf = vim.api.nvim_create_buf(false, true)
+  if not state.buf then
+    vim.notify("Failed to create preview buffer", vim.log.levels.ERROR)
+    return false
+  end
+
+  -- Set buffer options
+  vim.bo[state.buf].bufhidden = "wipe"
+  vim.bo[state.buf].filetype = "termlet_import_preview"
+  vim.bo[state.buf].buflisted = false
+  vim.bo[state.buf].modifiable = false
+
+  -- Create window
+  local win_opts = calculate_window_opts(state.preview_config)
+  state.win = vim.api.nvim_open_win(state.buf, true, win_opts)
+
+  if not state.win then
+    vim.api.nvim_buf_delete(state.buf, { force = true })
+    vim.notify("Failed to create preview window", vim.log.levels.ERROR)
+    return false
+  end
+
+  -- Set window options
+  vim.wo[state.win].cursorline = false
+  vim.wo[state.win].wrap = false
+  vim.wo[state.win].number = false
+  vim.wo[state.win].relativenumber = false
+  vim.wo[state.win].signcolumn = "no"
+
+  -- Auto-close on buffer leave
+  vim.api.nvim_create_autocmd("BufLeave", {
+    buffer = state.buf,
+    callback = function()
+      M.close_preview()
+    end,
+    once = true,
+  })
+
+  -- Set up keymaps
+  setup_keymaps()
+
+  -- Render initial content
+  render_preview()
+
+  return true
+end
+
+--- Close the preview UI
+function M.close_preview()
+  if state.win and vim.api.nvim_win_is_valid(state.win) then
+    vim.api.nvim_win_close(state.win, true)
+  end
+  state.win = nil
+  state.buf = nil
+  state.preview_data = nil
+  state.preview_callback = nil
+  state.preview_changes = nil
+  state.existing_scripts = nil
+end
+
+--- Check if preview UI is currently open
+---@return boolean
+function M.is_preview_open()
+  return state.win ~= nil and vim.api.nvim_win_is_valid(state.win)
+end
+
+--- Get current state (for testing)
+---@return table
+function M.get_state()
+  return {
+    preview_mode = state.preview_mode,
+    is_open = M.is_preview_open(),
+    has_data = state.preview_data ~= nil,
+  }
+end
+
+-- Expose internal functions for testing
+M._strip_sensitive = strip_sensitive
+M._validate_script = validate_script
+
+return M

--- a/lua/termlet/export_import.lua
+++ b/lua/termlet/export_import.lua
@@ -83,12 +83,10 @@ end
 ---@param path string Path to check
 ---@return boolean has_traversal
 local function has_path_traversal(path)
-  -- Check for ".." as a path component
-  if path == ".." then
-    return true
-  end
-  if path:match("^%.%./") or path:match("/%.\\.%./") or path:match("/%.%.$") then
-    return true
+  for component in path:gmatch("[^/\\]+") do
+    if component == ".." then
+      return true
+    end
   end
   return false
 end
@@ -345,16 +343,8 @@ function M.import_from_file(filepath)
     return nil, "File is empty: " .. filepath
   end
 
-  -- Parse based on file extension
-  local ext = vim.fn.fnamemodify(filepath, ":e"):lower()
-  local data, err
-
-  if ext == "json" then
-    data, err = M.parse_json(content)
-  else
-    -- Default to JSON
-    data, err = M.parse_json(content)
-  end
+  -- Parse as JSON (the only supported format)
+  local data, err = M.parse_json(content)
 
   if not data then
     return nil, err

--- a/tests/export_import_spec.lua
+++ b/tests/export_import_spec.lua
@@ -1,0 +1,924 @@
+-- Tests for TermLet Export/Import Module
+-- Run with: nvim --headless -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal_init.lua'}"
+
+describe("termlet.export_import", function()
+  local export_import
+
+  -- Sample scripts for testing
+  local test_scripts = {
+    {
+      name = "build",
+      filename = "build.sh",
+      description = "Build project",
+      cmd = "./build.sh",
+    },
+    {
+      name = "test",
+      filename = "test.sh",
+      description = "Run tests",
+      depends_on = { "build" },
+    },
+    {
+      name = "deploy",
+      filename = "deploy.sh",
+      description = "Deploy to production",
+      root_dir = "/home/user/project",
+      env = { NODE_ENV = "production" },
+      depends_on = { "build", "test" },
+      run_after_deps = "all",
+    },
+  }
+
+  before_each(function()
+    -- Clear cached module to get fresh state
+    package.loaded["termlet.export_import"] = nil
+    export_import = require("termlet.export_import")
+  end)
+
+  after_each(function()
+    if export_import.is_preview_open() then
+      export_import.close_preview()
+    end
+  end)
+
+  describe("export_json", function()
+    it("should export scripts to valid JSON", function()
+      local json_str, err = export_import.export_json(test_scripts)
+      assert.is_nil(err)
+      assert.is_not_nil(json_str)
+      assert.is_string(json_str)
+
+      -- Parse it back
+      local data = vim.fn.json_decode(json_str)
+      assert.is_not_nil(data)
+      assert.is_not_nil(data.scripts)
+      assert.equals(3, #data.scripts)
+    end)
+
+    it("should include version field", function()
+      local json_str, _err = export_import.export_json(test_scripts)
+      local data = vim.fn.json_decode(json_str)
+      assert.equals(1, data.version)
+    end)
+
+    it("should include metadata by default", function()
+      local json_str, _err = export_import.export_json(test_scripts)
+      local data = vim.fn.json_decode(json_str)
+      assert.is_not_nil(data.metadata)
+      assert.is_not_nil(data.metadata.exported_at)
+      assert.equals(3, data.metadata.script_count)
+    end)
+
+    it("should strip sensitive fields by default", function()
+      local json_str, _err = export_import.export_json(test_scripts)
+      local data = vim.fn.json_decode(json_str)
+
+      for _, script in ipairs(data.scripts) do
+        assert.is_nil(script.env)
+        assert.is_nil(script.root_dir)
+        assert.is_nil(script.search_dirs)
+      end
+    end)
+
+    it("should keep sensitive fields when strip_sensitive is false", function()
+      local json_str, _err = export_import.export_json(test_scripts, { strip_sensitive = false })
+      local data = vim.fn.json_decode(json_str)
+
+      -- deploy script should have env and root_dir
+      local deploy = nil
+      for _, script in ipairs(data.scripts) do
+        if script.name == "deploy" then
+          deploy = script
+          break
+        end
+      end
+      assert.is_not_nil(deploy)
+      assert.is_not_nil(deploy.env)
+      assert.is_not_nil(deploy.root_dir)
+    end)
+
+    it("should preserve non-sensitive fields", function()
+      local json_str, _err = export_import.export_json(test_scripts)
+      local data = vim.fn.json_decode(json_str)
+
+      local build = nil
+      for _, script in ipairs(data.scripts) do
+        if script.name == "build" then
+          build = script
+          break
+        end
+      end
+      assert.is_not_nil(build)
+      assert.equals("build", build.name)
+      assert.equals("build.sh", build.filename)
+      assert.equals("Build project", build.description)
+      assert.equals("./build.sh", build.cmd)
+    end)
+
+    it("should preserve depends_on", function()
+      local json_str, _err = export_import.export_json(test_scripts)
+      local data = vim.fn.json_decode(json_str)
+
+      local test_script = nil
+      for _, script in ipairs(data.scripts) do
+        if script.name == "test" then
+          test_script = script
+          break
+        end
+      end
+      assert.is_not_nil(test_script)
+      assert.is_not_nil(test_script.depends_on)
+      assert.equals(1, #test_script.depends_on)
+      assert.equals("build", test_script.depends_on[1])
+    end)
+
+    it("should return error for empty scripts", function()
+      local json_str, err = export_import.export_json({})
+      assert.is_nil(json_str)
+      assert.is_not_nil(err)
+    end)
+
+    it("should return error for nil scripts", function()
+      local json_str, err = export_import.export_json(nil)
+      assert.is_nil(json_str)
+      assert.is_not_nil(err)
+    end)
+
+    it("should exclude metadata when include_metadata is false", function()
+      local json_str, _err = export_import.export_json(test_scripts, { include_metadata = false })
+      local data = vim.fn.json_decode(json_str)
+      assert.is_nil(data.metadata)
+    end)
+
+    it("should filter to include_fields when specified", function()
+      local json_str, _err = export_import.export_json(test_scripts, {
+        include_fields = { "name", "filename", "description" },
+      })
+      local data = vim.fn.json_decode(json_str)
+
+      local build = nil
+      for _, script in ipairs(data.scripts) do
+        if script.name == "build" then
+          build = script
+          break
+        end
+      end
+      assert.is_not_nil(build)
+      assert.equals("build", build.name)
+      assert.equals("build.sh", build.filename)
+      assert.equals("Build project", build.description)
+      -- cmd should not be included since it's not in include_fields
+      assert.is_nil(build.cmd)
+    end)
+  end)
+
+  describe("export_to_file", function()
+    it("should write JSON to file", function()
+      local tmpfile = vim.fn.tempname() .. ".json"
+      local ok, err = export_import.export_to_file(test_scripts, tmpfile)
+      assert.is_true(ok)
+      assert.is_nil(err)
+
+      -- Verify file exists and contains valid JSON
+      assert.equals(1, vim.fn.filereadable(tmpfile))
+      local file = io.open(tmpfile, "r")
+      local content = file:read("*a")
+      file:close()
+
+      local data = vim.fn.json_decode(content)
+      assert.is_not_nil(data)
+      assert.equals(3, #data.scripts)
+
+      -- Cleanup
+      os.remove(tmpfile)
+    end)
+
+    it("should return error for invalid directory", function()
+      local ok, err = export_import.export_to_file(test_scripts, "/nonexistent/dir/file.json")
+      assert.is_false(ok)
+      assert.is_not_nil(err)
+    end)
+
+    it("should return error for empty scripts", function()
+      local tmpfile = vim.fn.tempname() .. ".json"
+      local ok, err = export_import.export_to_file({}, tmpfile)
+      assert.is_false(ok)
+      assert.is_not_nil(err)
+    end)
+  end)
+
+  describe("parse_json", function()
+    it("should parse valid JSON", function()
+      local json_str = vim.fn.json_encode({
+        version = 1,
+        scripts = {
+          { name = "build", filename = "build.sh" },
+        },
+      })
+
+      local data, err = export_import.parse_json(json_str)
+      assert.is_nil(err)
+      assert.is_not_nil(data)
+      assert.equals(1, data.version)
+      assert.equals(1, #data.scripts)
+    end)
+
+    it("should return error for invalid JSON", function()
+      local data, err = export_import.parse_json("not json{{{")
+      assert.is_nil(data)
+      assert.is_not_nil(err)
+      assert.is_truthy(err:find("Invalid JSON"))
+    end)
+
+    it("should return error for empty string", function()
+      local data, err = export_import.parse_json("")
+      assert.is_nil(data)
+      assert.is_not_nil(err)
+    end)
+
+    it("should return error for nil", function()
+      local data, err = export_import.parse_json(nil)
+      assert.is_nil(data)
+      assert.is_not_nil(err)
+    end)
+  end)
+
+  describe("validate_import_data", function()
+    it("should accept valid import data", function()
+      local data = {
+        version = 1,
+        scripts = {
+          { name = "build", filename = "build.sh" },
+          { name = "test", filename = "test.sh" },
+        },
+      }
+      local valid, err = export_import.validate_import_data(data)
+      assert.is_true(valid)
+      assert.is_nil(err)
+    end)
+
+    it("should reject non-table input", function()
+      local valid, err = export_import.validate_import_data("not a table")
+      assert.is_false(valid)
+      assert.is_not_nil(err)
+    end)
+
+    it("should reject missing scripts field", function()
+      local valid, err = export_import.validate_import_data({ version = 1 })
+      assert.is_false(valid)
+      assert.is_not_nil(err)
+    end)
+
+    it("should reject empty scripts list", function()
+      local valid, err = export_import.validate_import_data({ scripts = {} })
+      assert.is_false(valid)
+      assert.is_not_nil(err)
+    end)
+
+    it("should reject script without name", function()
+      local data = {
+        scripts = {
+          { filename = "build.sh" },
+        },
+      }
+      local valid, err = export_import.validate_import_data(data)
+      assert.is_false(valid)
+      assert.is_not_nil(err)
+    end)
+
+    it("should reject script with empty name", function()
+      local data = {
+        scripts = {
+          { name = "", filename = "build.sh" },
+        },
+      }
+      local valid, err = export_import.validate_import_data(data)
+      assert.is_false(valid)
+      assert.is_not_nil(err)
+    end)
+
+    it("should reject script without filename or dir_name+relative_path", function()
+      local data = {
+        scripts = {
+          { name = "build" },
+        },
+      }
+      local valid, err = export_import.validate_import_data(data)
+      assert.is_false(valid)
+      assert.is_not_nil(err)
+    end)
+
+    it("should accept script with dir_name and relative_path", function()
+      local data = {
+        scripts = {
+          { name = "build", dir_name = "scripts", relative_path = "build.sh" },
+        },
+      }
+      local valid, err = export_import.validate_import_data(data)
+      assert.is_true(valid)
+      assert.is_nil(err)
+    end)
+
+    it("should reject duplicate script names", function()
+      local data = {
+        scripts = {
+          { name = "build", filename = "build.sh" },
+          { name = "build", filename = "build2.sh" },
+        },
+      }
+      local valid, err = export_import.validate_import_data(data)
+      assert.is_false(valid)
+      assert.is_not_nil(err)
+      assert.is_truthy(err:find("Duplicate"))
+    end)
+
+    it("should reject invalid depends_on entries", function()
+      local data = {
+        scripts = {
+          { name = "build", filename = "build.sh", depends_on = { 123 } },
+        },
+      }
+      local valid, err = export_import.validate_import_data(data)
+      assert.is_false(valid)
+      assert.is_not_nil(err)
+    end)
+
+    it("should reject invalid run_after_deps value", function()
+      local data = {
+        scripts = {
+          { name = "build", filename = "build.sh", run_after_deps = "invalid" },
+        },
+      }
+      local valid, err = export_import.validate_import_data(data)
+      assert.is_false(valid)
+      assert.is_not_nil(err)
+    end)
+
+    it("should accept valid run_after_deps values", function()
+      for _, mode in ipairs({ "all", "any", "none" }) do
+        local data = {
+          scripts = {
+            { name = "build", filename = "build.sh", run_after_deps = mode },
+          },
+        }
+        local valid, err = export_import.validate_import_data(data)
+        assert.is_true(valid, "Should accept run_after_deps='" .. mode .. "': " .. tostring(err))
+        assert.is_nil(err)
+      end
+    end)
+
+    it("should accept scripts with optional fields", function()
+      local data = {
+        scripts = {
+          {
+            name = "build",
+            filename = "build.sh",
+            description = "Build project",
+            cmd = "./build.sh",
+            depends_on = { "install" },
+            run_after_deps = "all",
+          },
+          {
+            name = "install",
+            filename = "install.sh",
+          },
+        },
+      }
+      local valid, err = export_import.validate_import_data(data)
+      assert.is_true(valid)
+      assert.is_nil(err)
+    end)
+  end)
+
+  describe("import_from_file", function()
+    it("should import valid JSON file", function()
+      -- Create temp file with valid data
+      local tmpfile = vim.fn.tempname() .. ".json"
+      local data = {
+        version = 1,
+        scripts = {
+          { name = "build", filename = "build.sh" },
+          { name = "test", filename = "test.sh", depends_on = { "build" } },
+        },
+      }
+      local file = io.open(tmpfile, "w")
+      file:write(vim.fn.json_encode(data))
+      file:close()
+
+      local imported, err = export_import.import_from_file(tmpfile)
+      assert.is_nil(err)
+      assert.is_not_nil(imported)
+      assert.equals(2, #imported.scripts)
+      assert.equals("build", imported.scripts[1].name)
+
+      os.remove(tmpfile)
+    end)
+
+    it("should return error for nonexistent file", function()
+      local data, err = export_import.import_from_file("/nonexistent/file.json")
+      assert.is_nil(data)
+      assert.is_not_nil(err)
+      assert.is_truthy(err:find("not found"))
+    end)
+
+    it("should return error for invalid JSON file", function()
+      local tmpfile = vim.fn.tempname() .. ".json"
+      local file = io.open(tmpfile, "w")
+      file:write("not valid json{{{")
+      file:close()
+
+      local data, err = export_import.import_from_file(tmpfile)
+      assert.is_nil(data)
+      assert.is_not_nil(err)
+
+      os.remove(tmpfile)
+    end)
+
+    it("should return error for empty file", function()
+      local tmpfile = vim.fn.tempname() .. ".json"
+      local file = io.open(tmpfile, "w")
+      file:write("")
+      file:close()
+
+      local data, err = export_import.import_from_file(tmpfile)
+      assert.is_nil(data)
+      assert.is_not_nil(err)
+
+      os.remove(tmpfile)
+    end)
+
+    it("should validate imported data", function()
+      -- Create file with invalid data (no scripts field)
+      local tmpfile = vim.fn.tempname() .. ".json"
+      local file = io.open(tmpfile, "w")
+      file:write(vim.fn.json_encode({ version = 1 }))
+      file:close()
+
+      local data, err = export_import.import_from_file(tmpfile)
+      assert.is_nil(data)
+      assert.is_not_nil(err)
+
+      os.remove(tmpfile)
+    end)
+  end)
+
+  describe("merge_scripts", function()
+    it("should add new scripts", function()
+      local existing = {
+        { name = "build", filename = "build.sh" },
+      }
+      local imported = {
+        { name = "test", filename = "test.sh" },
+        { name = "deploy", filename = "deploy.sh" },
+      }
+
+      local merged, changes = export_import.merge_scripts(existing, imported)
+      assert.equals(3, #merged)
+      assert.equals(2, #changes.added)
+      assert.equals(0, #changes.updated)
+      assert.equals(1, #changes.unchanged)
+    end)
+
+    it("should update existing scripts", function()
+      local existing = {
+        { name = "build", filename = "build.sh", description = "Old description" },
+      }
+      local imported = {
+        { name = "build", filename = "build.sh", description = "New description" },
+      }
+
+      local merged, changes = export_import.merge_scripts(existing, imported)
+      assert.equals(1, #merged)
+      assert.equals(0, #changes.added)
+      assert.equals(1, #changes.updated)
+      assert.equals("New description", merged[1].description)
+    end)
+
+    it("should merge fields from imported into existing", function()
+      local existing = {
+        { name = "build", filename = "build.sh", root_dir = "/project" },
+      }
+      local imported = {
+        { name = "build", filename = "build.sh", description = "Build project" },
+      }
+
+      local merged, _changes = export_import.merge_scripts(existing, imported)
+      -- Should have both root_dir (from existing) and description (from imported)
+      assert.equals("/project", merged[1].root_dir)
+      assert.equals("Build project", merged[1].description)
+    end)
+
+    it("should handle empty existing list", function()
+      local existing = {}
+      local imported = {
+        { name = "build", filename = "build.sh" },
+      }
+
+      local merged, changes = export_import.merge_scripts(existing, imported)
+      assert.equals(1, #merged)
+      assert.equals(1, #changes.added)
+    end)
+
+    it("should handle empty imported list", function()
+      local existing = {
+        { name = "build", filename = "build.sh" },
+      }
+      local imported = {}
+
+      local merged, changes = export_import.merge_scripts(existing, imported)
+      assert.equals(1, #merged)
+      assert.equals(0, #changes.added)
+      assert.equals(0, #changes.updated)
+      assert.equals(1, #changes.unchanged)
+    end)
+
+    it("should not modify original tables", function()
+      local existing = {
+        { name = "build", filename = "build.sh", description = "Old" },
+      }
+      local imported = {
+        { name = "build", filename = "build.sh", description = "New" },
+      }
+
+      local _merged, _changes = export_import.merge_scripts(existing, imported)
+      assert.equals("Old", existing[1].description)
+    end)
+
+    it("should handle mixed add and update", function()
+      local existing = {
+        { name = "build", filename = "build.sh" },
+        { name = "lint", filename = "lint.sh" },
+      }
+      local imported = {
+        { name = "build", filename = "build.sh", description = "Updated" },
+        { name = "test", filename = "test.sh" },
+      }
+
+      local merged, changes = export_import.merge_scripts(existing, imported)
+      assert.equals(3, #merged)
+      assert.equals(1, #changes.added)
+      assert.equals(1, #changes.updated)
+      assert.equals(1, #changes.unchanged)
+      assert.equals("test", changes.added[1])
+      assert.equals("build", changes.updated[1])
+      assert.equals("lint", changes.unchanged[1])
+    end)
+  end)
+
+  describe("_strip_sensitive", function()
+    it("should strip default sensitive fields", function()
+      local script = {
+        name = "deploy",
+        filename = "deploy.sh",
+        env = { NODE_ENV = "production" },
+        root_dir = "/home/user/project",
+        search_dirs = { "scripts" },
+        description = "Deploy",
+      }
+
+      local cleaned = export_import._strip_sensitive(script)
+      assert.is_nil(cleaned.env)
+      assert.is_nil(cleaned.root_dir)
+      assert.is_nil(cleaned.search_dirs)
+      assert.equals("deploy", cleaned.name)
+      assert.equals("deploy.sh", cleaned.filename)
+      assert.equals("Deploy", cleaned.description)
+    end)
+
+    it("should strip custom fields", function()
+      local script = {
+        name = "build",
+        filename = "build.sh",
+        description = "Build",
+        cmd = "./build.sh",
+      }
+
+      local cleaned = export_import._strip_sensitive(script, { "description", "cmd" })
+      assert.is_nil(cleaned.description)
+      assert.is_nil(cleaned.cmd)
+      assert.equals("build", cleaned.name)
+      assert.equals("build.sh", cleaned.filename)
+    end)
+
+    it("should not modify original table", function()
+      local script = {
+        name = "deploy",
+        env = { NODE_ENV = "production" },
+      }
+
+      local _cleaned = export_import._strip_sensitive(script)
+      assert.is_not_nil(script.env)
+    end)
+
+    it("should deep copy table values", function()
+      local script = {
+        name = "build",
+        filename = "build.sh",
+        depends_on = { "install" },
+      }
+
+      local cleaned = export_import._strip_sensitive(script)
+      assert.is_not_nil(cleaned.depends_on)
+      -- Modifying the copy should not affect the original
+      table.insert(cleaned.depends_on, "lint")
+      assert.equals(1, #script.depends_on)
+    end)
+  end)
+
+  describe("_validate_script", function()
+    it("should accept valid script with filename", function()
+      local valid, err = export_import._validate_script({
+        name = "build",
+        filename = "build.sh",
+      })
+      assert.is_true(valid)
+      assert.is_nil(err)
+    end)
+
+    it("should accept valid script with dir_name and relative_path", function()
+      local valid, err = export_import._validate_script({
+        name = "build",
+        dir_name = "scripts",
+        relative_path = "build.sh",
+      })
+      assert.is_true(valid)
+      assert.is_nil(err)
+    end)
+
+    it("should reject non-table", function()
+      local valid, err = export_import._validate_script("not a table")
+      assert.is_false(valid)
+      assert.is_not_nil(err)
+    end)
+
+    it("should reject missing name", function()
+      local valid, err = export_import._validate_script({ filename = "build.sh" })
+      assert.is_false(valid)
+      assert.is_not_nil(err)
+    end)
+
+    it("should reject empty name", function()
+      local valid, err = export_import._validate_script({ name = "", filename = "build.sh" })
+      assert.is_false(valid)
+      assert.is_not_nil(err)
+    end)
+
+    it("should reject missing filename and dir_name", function()
+      local valid, err = export_import._validate_script({ name = "build" })
+      assert.is_false(valid)
+      assert.is_not_nil(err)
+    end)
+  end)
+
+  describe("roundtrip", function()
+    it("should roundtrip export/import through JSON", function()
+      local scripts = {
+        { name = "build", filename = "build.sh", description = "Build project" },
+        { name = "test", filename = "test.sh", depends_on = { "build" } },
+      }
+
+      -- Export
+      local json_str, export_err = export_import.export_json(scripts, { strip_sensitive = false })
+      assert.is_nil(export_err)
+
+      -- Parse
+      local data, parse_err = export_import.parse_json(json_str)
+      assert.is_nil(parse_err)
+
+      -- Validate
+      local valid, validate_err = export_import.validate_import_data(data)
+      assert.is_true(valid)
+      assert.is_nil(validate_err)
+
+      -- Compare
+      assert.equals(2, #data.scripts)
+      assert.equals("build", data.scripts[1].name)
+      assert.equals("test", data.scripts[2].name)
+      assert.equals(1, #data.scripts[2].depends_on)
+    end)
+
+    it("should roundtrip through file", function()
+      local scripts = {
+        { name = "build", filename = "build.sh", description = "Build project" },
+        { name = "test", filename = "test.sh", depends_on = { "build" } },
+      }
+
+      local tmpfile = vim.fn.tempname() .. ".json"
+
+      -- Export to file
+      local ok, export_err = export_import.export_to_file(scripts, tmpfile, { strip_sensitive = false })
+      assert.is_true(ok)
+      assert.is_nil(export_err)
+
+      -- Import from file
+      local data, import_err = export_import.import_from_file(tmpfile)
+      assert.is_nil(import_err)
+      assert.is_not_nil(data)
+      assert.equals(2, #data.scripts)
+
+      os.remove(tmpfile)
+    end)
+  end)
+
+  describe("preview UI", function()
+    it("should open preview with valid data", function()
+      local data = {
+        scripts = {
+          { name = "build", filename = "build.sh" },
+        },
+      }
+
+      local result = export_import.open_preview(data, {}, function() end)
+      assert.is_true(result)
+      assert.is_true(export_import.is_preview_open())
+    end)
+
+    it("should return false for empty data", function()
+      local data = { scripts = {} }
+      local result = export_import.open_preview(data, {}, function() end)
+      assert.is_false(result)
+    end)
+
+    it("should return false for nil data", function()
+      local result = export_import.open_preview(nil, {}, function() end)
+      assert.is_false(result)
+    end)
+
+    it("should close preview", function()
+      local data = {
+        scripts = {
+          { name = "build", filename = "build.sh" },
+        },
+      }
+
+      export_import.open_preview(data, {}, function() end)
+      assert.is_true(export_import.is_preview_open())
+
+      export_import.close_preview()
+      assert.is_false(export_import.is_preview_open())
+    end)
+
+    it("should not error when closing with no preview open", function()
+      export_import.close_preview()
+      assert.is_false(export_import.is_preview_open())
+    end)
+
+    it("should close existing preview when opening new one", function()
+      local data = {
+        scripts = {
+          { name = "build", filename = "build.sh" },
+        },
+      }
+
+      export_import.open_preview(data, {}, function() end)
+      assert.is_true(export_import.is_preview_open())
+
+      -- Opening another should close the first
+      local data2 = {
+        scripts = {
+          { name = "test", filename = "test.sh" },
+        },
+      }
+      export_import.open_preview(data2, {}, function() end)
+      assert.is_true(export_import.is_preview_open())
+    end)
+  end)
+
+  describe("get_state", function()
+    it("should return initial state", function()
+      local state = export_import.get_state()
+      assert.equals("merge", state.preview_mode)
+      assert.is_false(state.is_open)
+      assert.is_false(state.has_data)
+    end)
+
+    it("should reflect open state", function()
+      local data = {
+        scripts = {
+          { name = "build", filename = "build.sh" },
+        },
+      }
+
+      export_import.open_preview(data, {}, function() end)
+      local state = export_import.get_state()
+      assert.is_true(state.is_open)
+      assert.is_true(state.has_data)
+    end)
+  end)
+end)
+
+describe("termlet export/import integration", function()
+  local termlet
+
+  before_each(function()
+    -- Clear cached modules
+    package.loaded["termlet"] = nil
+    package.loaded["termlet.export_import"] = nil
+    termlet = require("termlet")
+  end)
+
+  after_each(function()
+    if termlet.close_import_preview then
+      termlet.close_import_preview()
+    end
+    termlet.close_all_terminals()
+  end)
+
+  describe("setup", function()
+    it("should expose export_import module", function()
+      termlet.setup({ scripts = {} })
+      assert.is_not_nil(termlet.export_import)
+    end)
+
+    it("should expose export/import functions", function()
+      termlet.setup({ scripts = {} })
+      assert.is_function(termlet.export_scripts)
+      assert.is_function(termlet.export_to_file)
+      assert.is_function(termlet.import_from_file)
+      assert.is_function(termlet.close_import_preview)
+      assert.is_function(termlet.is_import_preview_open)
+    end)
+  end)
+
+  describe("export_scripts", function()
+    it("should export configured scripts", function()
+      termlet.setup({
+        scripts = {
+          { name = "build", filename = "build.sh", description = "Build" },
+          { name = "test", filename = "test.sh" },
+        },
+      })
+
+      local json_str, err = termlet.export_scripts()
+      assert.is_nil(err)
+      assert.is_not_nil(json_str)
+
+      local data = vim.fn.json_decode(json_str)
+      assert.equals(2, #data.scripts)
+    end)
+
+    it("should return nil when no scripts configured", function()
+      termlet.setup({ scripts = {} })
+      local json_str, err = termlet.export_scripts()
+      assert.is_nil(json_str)
+      assert.is_not_nil(err)
+    end)
+
+    it("should pass options through", function()
+      termlet.setup({
+        scripts = {
+          { name = "build", filename = "build.sh", env = { VAR = "value" } },
+        },
+      })
+
+      -- With strip_sensitive=false
+      local json_str, _err = termlet.export_scripts({ strip_sensitive = false })
+      local data = vim.fn.json_decode(json_str)
+      assert.is_not_nil(data.scripts[1].env)
+
+      -- With default (strip_sensitive=true)
+      json_str, _err = termlet.export_scripts()
+      data = vim.fn.json_decode(json_str)
+      assert.is_nil(data.scripts[1].env)
+    end)
+  end)
+
+  describe("export_to_file", function()
+    it("should export to specified file", function()
+      termlet.setup({
+        scripts = {
+          { name = "build", filename = "build.sh" },
+        },
+      })
+
+      local tmpfile = vim.fn.tempname() .. ".json"
+      termlet.export_to_file(tmpfile)
+
+      assert.equals(1, vim.fn.filereadable(tmpfile))
+
+      local file = io.open(tmpfile, "r")
+      local content = file:read("*a")
+      file:close()
+
+      local data = vim.fn.json_decode(content)
+      assert.equals(1, #data.scripts)
+
+      os.remove(tmpfile)
+    end)
+  end)
+
+  describe("is_import_preview_open", function()
+    it("should return false initially", function()
+      termlet.setup({ scripts = {} })
+      assert.is_false(termlet.is_import_preview_open())
+    end)
+  end)
+
+  describe("_do_import", function()
+    it("should report error for nonexistent file", function()
+      termlet.setup({ scripts = {} })
+      -- Should not error, just notify
+      termlet._do_import("/nonexistent/file.json")
+    end)
+  end)
+end)

--- a/tests/export_import_spec.lua
+++ b/tests/export_import_spec.lua
@@ -765,6 +765,27 @@ describe("termlet.export_import", function()
       assert.is_truthy(err:find("path traversal"))
     end)
 
+    it("should reject filename with mid-path traversal", function()
+      local valid, err = export_import._validate_script({
+        name = "build",
+        filename = "scripts/../../../etc/passwd",
+      })
+      assert.is_false(valid)
+      assert.is_not_nil(err)
+      assert.is_truthy(err:find("path traversal"))
+    end)
+
+    it("should reject relative_path with mid-path traversal", function()
+      local valid, err = export_import._validate_script({
+        name = "build",
+        dir_name = "scripts",
+        relative_path = "sub/../../../etc/passwd",
+      })
+      assert.is_false(valid)
+      assert.is_not_nil(err)
+      assert.is_truthy(err:find("path traversal"))
+    end)
+
     it("should accept filename with subdirectory path", function()
       local valid, err = export_import._validate_script({
         name = "build",
@@ -786,6 +807,15 @@ describe("termlet.export_import", function()
 
     it("should detect .. at end of path", function()
       assert.is_true(export_import._has_path_traversal("scripts/.."))
+    end)
+
+    it("should detect .. in middle of path", function()
+      assert.is_true(export_import._has_path_traversal("foo/../bar"))
+      assert.is_true(export_import._has_path_traversal("/scripts/../../../etc/passwd"))
+    end)
+
+    it("should detect .. with backslash separators", function()
+      assert.is_true(export_import._has_path_traversal("foo\\..\\bar"))
     end)
 
     it("should not flag normal paths", function()


### PR DESCRIPTION
## Summary
- Add `export_import.lua` module for serializing/deserializing script configurations to JSON
- Integrate export/import API into main `init.lua` with `M.export_scripts()`, `M.export_to_file()`, and `M.import_from_file()`
- Interactive preview UI for imports showing merge/replace modes and change summaries
- Comprehensive test suite with 71 test cases covering export, import, validation, merge, roundtrip, and UI

Closes #59

## Changes
| File | Description |
|------|-------------|
| `lua/termlet/export_import.lua` | New module: JSON export/import, validation, merge logic, preview UI |
| `lua/termlet/init.lua` | Integration: load module, expose API functions |
| `tests/export_import_spec.lua` | 71 test cases covering all functionality |

## Features
- **Export**: `M.export_scripts(opts)` / `M.export_to_file(filepath, opts)` - serialize scripts to JSON with automatic sensitive field stripping (env vars, absolute paths)
- **Import**: `M.import_from_file(filepath)` - parse, validate, and preview before applying
- **Preview UI**: floating window showing imported scripts, merge/replace toggle, change summary
- **Merge mode**: adds new scripts, updates existing ones by name
- **Replace mode**: replaces entire script configuration
- **Validation**: checks script structure, field types, duplicate names, dependency format

## Test plan
- [x] All 135 existing tests pass (0 failures, 0 errors)
- [x] 71 new export/import tests pass
- [x] luacheck lint passes with 0 warnings
- [x] stylua formatting passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)