### PR TITLE
docs: Add keybinding config and API to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ Here's the full configuration structure:
     border = "rounded", -- Menu border style
     title = " TermLet Scripts " -- Menu window title
   },
+  keybindings = {
+    width_ratio = 0.6,  -- Keybindings window width (fraction of screen)
+    height_ratio = 0.5, -- Keybindings window height (fraction of screen)
+    border = "rounded", -- Keybindings border style
+    title = " TermLet Keybindings " -- Keybindings window title
+  },
   search = {
     exclude_dirs = {},   -- Directories to exclude from search (defaults include node_modules, .git, etc.)
     exclude_hidden = true, -- Exclude hidden directories (starting with .)
@@ -410,6 +416,9 @@ print(bindings["build"]) -- "<leader>b"
 require("termlet").open_keybindings()
 require("termlet").close_keybindings()
 require("termlet").toggle_keybindings()
+
+-- Check if keybindings UI is open
+local is_open = require("termlet").is_keybindings_open()
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Add `keybindings` configuration block (width_ratio, height_ratio, border, title) to the full configuration structure in the README, matching the existing `menu` config pattern
- Add missing `is_keybindings_open()` method to the programmatic API section

Both additions were identified as documentation gaps — the keybinding feature was merged in PR #22 but these two items were not included in the README.

Config defaults verified against `lua/termlet/keybindings.lua` (lines 24-28). API method verified at `lua/termlet/init.lua:1179`.

Closes #33

## Test plan

- [x] `make lint` passes (0 warnings, 0 errors)
- [x] `make test` passes (135/135 tests, 0 failures)
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)