### PR TITLE
docs: Update README with keybinding configuration UI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ Here's the full configuration structure:
     border = "rounded", -- Menu border style
     title = " TermLet Scripts " -- Menu window title
   },
+  keybindings = {
+    width_ratio = 0.6,  -- Keybindings window width (fraction of screen)
+    height_ratio = 0.5, -- Keybindings window height (fraction of screen)
+    border = "rounded", -- Keybindings border style
+    title = " TermLet Keybindings " -- Keybindings window title
+  },
   search = {
     exclude_dirs = {},   -- Directories to exclude from search (defaults include node_modules, .git, etc.)
     exclude_hidden = true, -- Exclude hidden directories (starting with .)
@@ -410,6 +416,9 @@ print(bindings["build"]) -- "<leader>b"
 require("termlet").open_keybindings()
 require("termlet").close_keybindings()
 require("termlet").toggle_keybindings()
+
+-- Check if keybindings UI is open
+local is_open = require("termlet").is_keybindings_open()
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Add `keybindings` configuration option to the full configuration structure block in the README, documenting `width_ratio`, `height_ratio`, `border`, and `title` options (matching defaults from `lua/termlet/keybindings.lua`)
- Add missing `is_keybindings_open()` method to the programmatic API section, completing the documented API surface

Closes #33

## Test plan
- [x] Verified `make lint` passes (no Lua files modified)
- [x] Cross-referenced config defaults against `lua/termlet/keybindings.lua` `default_config` (lines 24-37)
- [x] Cross-referenced `is_keybindings_open()` against `lua/termlet/init.lua` (line 1179)
- [ ] Review README rendering on GitHub to confirm markdown displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)