### PR TITLE
fix: normalize consecutive underscores in function names

### DIFF
--- a/lua/termlet/init.lua
+++ b/lua/termlet/init.lua
@@ -746,7 +746,7 @@ local function apply_keybindings()
     local key = saved_keybindings[script.name]
     if key and key ~= "" then
       -- Create keybinding for this script
-      local function_name = "run_" .. script.name:gsub("[%s%-%.]", "_"):lower()
+      local function_name = "run_" .. script.name:gsub("[%s%-%.]", "_"):gsub("_+", "_"):lower()
       local run_func = M[function_name]
 
       if run_func then
@@ -838,7 +838,7 @@ function M.setup(user_config)
     end
 
     -- Create sanitized function name
-    local function_name = "run_" .. script.name:gsub("[%s%-%.]", "_"):lower()
+    local function_name = "run_" .. script.name:gsub("[%s%-%.]", "_"):gsub("_+", "_"):lower()
 
     -- Ensure function name is valid
     if not function_name:match("^[a-zA-Z_][a-zA-Z0-9_]*$") then


### PR DESCRIPTION
## Summary

Fixes an edge case where consecutive special characters in script names result in multiple underscores in the generated function name.

**Before:**
- `"my--script"` → `"run_my__script"` (double underscore)
- `"build - test"` → `"run_build___test"` (triple underscore)

**After:**
- `"my--script"` → `"run_my_script"` (single underscore)
- `"build - test"` → `"run_build_test"` (single underscore)

## Fix

Added `gsub("_+", "_")` to normalize consecutive underscores after replacing special characters with underscores.

Fixes #{16}

## Test

The fix was verified by checking both occurrences of the pattern in `lua/termlet/init.lua` (lines 749 and 841).
